### PR TITLE
Fix for "erresc: unknown str ESC]8" stderr spam

### DIFF
--- a/st.c
+++ b/st.c
@@ -2014,6 +2014,10 @@ strhandle(void)
 			if (narg > 1)
 				xsettitle(strescseq.args[1]);
 			return;
+		/* NOTE: 2024-05-14 (yama):
+		   Not entirely sure how and why this single line fixes the
+		   `erresc: unknown str ESC]8` issue */
+		case 8:
 		case 52:
 			if (narg > 2 && allowwindowops) {
 				dec = base64dec(strescseq.args[2]);


### PR DESCRIPTION
This is a single line fix for the endless standard stderr IO spam generated by the fact that st has not implemented the xterm hyperlink extension.

Some context:
- st does not properly support the hyperlink extension/proposal that some other xterm based terminal emulators support.
- We currently print an error whenever the specific escape codes are encountered.
- Due to this, whenever I open a terminal my log files are endlessly flooded with the message: `erresc: unknown str ESC]8`.

The fix seems to work on multiple different builds of st (I've tested two so far). I've tested the `siduck/snazzy-terminal` build, and the `mdrdotx/st` build.

I've been using this patch for two weeks or so and I haven't noticed any problems so I think it is okay.

Here is a short gif of the mayhem: 

![ezgif-6-56cbccb863](https://github.com/mrdotx/st/assets/106480928/dcde226a-8110-4750-9cf1-265c809a376b)
